### PR TITLE
Fix RC application displaying on HMI app list

### DIFF
--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -126,7 +126,7 @@ SDL.RController = SDL.SDLController.extend(
               // for not initialized applications
               appID: params.appID,
               appName: params.appName,
-              deviceName: params.deviceName,
+              deviceName: params.deviceInfo.name,
               appType: params.appType,
               isMedia: 0,
               disabledToActivate: params.greyOut ? true : false
@@ -141,7 +141,7 @@ SDL.RController = SDL.SDLController.extend(
               //Magic number 1 - Default non-media model
               appID: params.appID,
               appName: params.appName,
-              deviceName: params.deviceName,
+              deviceName: params.deviceInfo.name,
               appType: params.appType,
               isMedia: false,
               initialized: true,
@@ -155,7 +155,7 @@ SDL.RController = SDL.SDLController.extend(
             {
               appID: params.appID,
               appName: params.appName,
-              deviceName: params.deviceName,
+              deviceName: params.deviceInfo.name,
               appType: params.appType,
               isMedia: applicationType == 0,
               initialized: true,

--- a/app/model/sdl/RModel.js
+++ b/app/model/sdl/RModel.js
@@ -59,7 +59,7 @@ SDL.RModel = SDL.SDLModel.extend({
    *
    * @param {Object}
    */
-  driverDevice: false,
+  driverDevice: true,
 
   /**
    * Current drivers device flag

--- a/app/view/info/appsView.js
+++ b/app/view/info/appsView.js
@@ -77,12 +77,7 @@ SDL.InfoAppsView = Em.ContainerView.create({
                  }
                  )
                );
-      } else if (apps[i].appType.indexOf('REMOTE_CONTROL') != -1 &&
-        apps[i].level != 'NONE' &&
-        apps[i].level != 'BACKGROUND' ||
-        SDL.SDLModel.driverDeviceInfo &&
-        apps[i].deviceName === SDL.SDLModel.driverDeviceInfo.name) {
-
+      } else if (apps[i].appType.indexOf('REMOTE_CONTROL') != -1) {
         var driverDevice = (
         SDL.SDLModel.driverDeviceInfo &&
         apps[i].deviceName == SDL.SDLModel.driverDeviceInfo.name);
@@ -102,9 +97,8 @@ SDL.InfoAppsView = Em.ContainerView.create({
                    classNames: 'list-item button',
                    iconBinding: 'SDL.SDLModel.data.registeredApps.' + appIndex +
                    '.appIcon',
-                   disabled: false
-                 }
-                 )
+                   disabled: driverDevice ? apps[i].disabledToActivate : true
+                 })
                );
       }
     }


### PR DESCRIPTION
Fixed RC application displaying on HMI app list. The root cause of defect was that for RC applications was implemented a wrong logic which blocks this apps displaying in view.

In this pull request:
- Fixed `deviceName` param assignment. This param will be used for checking is current connected device is drivers or passengers. Because of wrong assignment any device applications was always be treated as passengers
- Set `driverDevice` property to true. This flag is used to treat first connected device as drivers by default
- Fixed logic of displaying registered RC applications in app view

