### PR TITLE
Fix popup message on UpdateAppList without changes

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -944,13 +944,13 @@ SDL.SDLController = Em.Object.extend(
      * @constructor
      */
     UpdateAppList: function(params) {
-      var message = 'Was found ' + params.applications.length + ' apps';
-      SDL.PopUp.create().appendTo('body').popupActivate(message);
+      var list_changed = false;
       for (var i = SDL.SDLModel.data.registeredApps.length - 1; i >= 0; i--) {
         if (params.applications.filterProperty(
             'appID',
             SDL.SDLModel.data.registeredApps[i].appID
           ).length === 0) {
+          list_changed = true;
           SDL.SDLModel.onAppUnregistered(SDL.SDLModel.data.registeredApps[i]);
         }
       }
@@ -959,11 +959,25 @@ SDL.SDLController = Em.Object.extend(
             'appID',
             params.applications[i].appID
           ).length === 0) {
+          list_changed = true;
           SDL.SDLModel.onAppRegistered(params.applications[i]);
-        } else {
           SDL.SDLController.getApplicationModel(params.applications[i].appID)
-            .set('disabledToActivate', params.applications[i].greyOut);
+            .set('isUpdatedByAppList', true);
+        } else {
+          var appModel =
+            SDL.SDLController.getApplicationModel(
+              params.applications[i].appID
+          );
+          if (!appModel.isUpdatedByAppList) {
+            list_changed = true;
+            appModel.set('isUpdatedByAppList', true);
+          }
+          appModel.set('disabledToActivate', params.applications[i].greyOut);
         }
+      }
+      if (list_changed) {
+        var message = 'Was found ' + params.applications.length + ' apps';
+        SDL.PopUp.create().appendTo('body').popupActivate(message);
       }
       SDL.InfoAppsView.showAppList();
     },


### PR DESCRIPTION
When SDL sends UpdateAppList for already registered application, we don't need to show popup every time