### PR TITLE
Fix direct tune delete button correct disabling

### DIFF
--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -673,15 +673,23 @@ SDL.RadioModel = Em.Object.create({
       //FFW.RC.OnPresetsChanged(this.preset);
     },
 
+  afterDirectTune: function() {
+      this.set('station', this.temp);
+      this.set('directTuneFinished', false);
+      this.set('directTuneKeypressed', false);
+      this.set('directTuneKeyItems', []);
+  },
+
+  beforeDirectTune: function() {
+      this.set('temp', this.station);
+  },
+
   directTune: function() {
       this.toggleProperty('tuneRadio');
       if (this.tuneRadio) {
-        this.set('temp', this.station);
+        this.beforeDirectTune();
       } else {
-        this.set('station', this.temp);
-        this.set('directTuneFinished', false);
-        this.set('directTuneKeypressed', false);
-        this.set('directTuneKeyItems', []);
+        this.afterDirectTune();
       }
     },
 
@@ -975,6 +983,9 @@ SDL.RadioModel = Em.Object.create({
   },
 
   tuneUp: function() {
+      if (this.tuneRadio) {
+        this.afterDirectTune();
+      }
       var data = this.changeFrequency(1);
       this.updateRadioFrequency();
       this.checkRadioDetailsSongInfo(data);
@@ -982,6 +993,9 @@ SDL.RadioModel = Em.Object.create({
     },
 
   tuneDown: function() {
+      if (this.tuneRadio) {
+        this.afterDirectTune();
+      }
       var data = this.changeFrequency(-1);
       this.updateRadioFrequency();
       this.checkRadioDetailsSongInfo(data);


### PR DESCRIPTION
There was a problems if while editing radio frequency manually you decide to tune up/down current frequency
then delete button still active.