### PR TITLE
Fix app activation on RC disabling

### DIFF
--- a/app/controller/sdl/MediaController.js
+++ b/app/controller/sdl/MediaController.js
@@ -79,11 +79,9 @@ SDL.SDLMediaController = Em.Object.create(
       FFW.BasicCommunication.ActivateApp(this.currentAppId);
     },
     /**
-     * Method hides sdl activation button and sdl application
-     *
-     * @param {Number}
+     * Deactivate specific application
      */
-    onDeleteApplication: function(appID) {
+    deactivateApp: function(appID) {
       if (this.currentAppId == appID) {
         if (SDL.States.media.sdlmedia.active ||
           SDL.SDLController.model) {
@@ -97,6 +95,26 @@ SDL.SDLMediaController = Em.Object.create(
         SDL.SDLModel.data.set('limitedExist', false);
         this.set('currentAppId', null);
       }
+    },
+    /**
+     * Deactivate currently active RC application
+     */
+    deactivateActiveRcApp: function() {
+      if (this.currentAppId) {
+        var app_model =
+          SDL.SDLController.getApplicationModel(this.currentAppId);
+        if (app_model.appType.indexOf('REMOTE_CONTROL') != -1) {
+          this.deactivateApp(this.currentAppId);
+        }
+      }
+    },
+    /**
+     * Method hides sdl activation button and sdl application
+     *
+     * @param {Number}
+     */
+    onDeleteApplication: function(appID) {
+      this.deactivateApp(appID);
       SDL.SDLModel.stopStream(appID);
       SDL.SDLModel.data.get('registeredApps').removeObjects(
         SDL.SDLModel.data.get('registeredApps').filterProperty('appID', appID)

--- a/app/controller/sdl/NonMediaController.js
+++ b/app/controller/sdl/NonMediaController.js
@@ -79,11 +79,9 @@ SDL.NonMediaController = Em.Object.create(
       FFW.BasicCommunication.ActivateApp(this.currentAppId);
     },
     /**
-     * Method hides sdl activation button and sdl application
-     *
-     * @param {Number}
+     * Deactivate current application
      */
-    onDeleteApplication: function(appID) {
+    deactivateApp: function(appID) {
       if (this.currentAppId == appID) {
         if (SDL.States.info.nonMedia.active ||
           SDL.SDLController.model) {
@@ -94,6 +92,26 @@ SDL.NonMediaController = Em.Object.create(
         SDL.InfoController.set('activeState', 'info.apps');
         this.set('currentAppId', null);
       }
+    },
+    /**
+     * Deactivate currently active RC application
+     */
+    deactivateActiveRcApp: function() {
+      if (this.currentAppId) {
+        var app_model =
+          SDL.SDLController.getApplicationModel(this.currentAppId);
+        if (app_model.appType.indexOf('REMOTE_CONTROL') != -1) {
+          this.deactivateApp(this.currentAppId);
+        }
+      }
+    },
+    /**
+     * Method hides sdl activation button and sdl application
+     *
+     * @param {Number}
+     */
+    onDeleteApplication: function(appID) {
+      this.deactivateApp(appID);
       SDL.SDLModel.data.get('registeredApps').removeObjects(
         SDL.SDLModel.data.get('registeredApps').filterProperty('appID', appID)
       );

--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -204,6 +204,9 @@ SDL.RController = SDL.SDLController.extend(
      */
     toggleRSDLFunctionality: function() {
       SDL.SDLModel.toggleProperty('reverseFunctionalityEnabled');
+      SDL.SDLMediaController.deactivateActiveRcApp();
+      SDL.NonMediaController.deactivateActiveRcApp();
+      SDL.InfoAppsView.showAppList();
       FFW.RC.OnRemoteControlSettings(
         SDL.SDLModel.reverseFunctionalityEnabled,
         SDL.SDLModel.reverseAccessMode

--- a/app/view/info/appsView.js
+++ b/app/view/info/appsView.js
@@ -47,6 +47,13 @@ SDL.InfoAppsView = Em.ContainerView.create({
     'listOfApplications'
   ],
 
+  isRcAppDisabled: function(app, driverDevice) {
+    if (!SDL.SDLModel.reverseFunctionalityEnabled) {
+      return true;
+    }
+    return driverDevice ? app.disabledToActivate : true;
+  },
+
   /**
    * Function to add application to application list
    */
@@ -96,7 +103,7 @@ SDL.InfoAppsView = Em.ContainerView.create({
                    classNames: 'list-item button',
                    iconBinding: 'SDL.SDLModel.data.registeredApps.' + appIndex +
                    '.appIcon',
-                   disabled: driverDevice ? apps[i].disabledToActivate : true
+                   disabled: SDL.InfoAppsView.isRcAppDisabled(apps[i], driverDevice)
                  })
                );
       }


### PR DESCRIPTION
In case RSDL functionality is disabled in HMI options menu - HMI must disallow user to activate any RC applications. Also HMI should deactivate RC applications which was not in full mode.