### PR TITLE
Fix AC <-> AC_MAX interaction for SetInteriorVehicleData 

### DIFF
--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -504,6 +504,31 @@ SDL.RController = SDL.SDLController.extend(
         }
       }
       return result;
+    },
+    /**
+     * Get diff between lhs and rhs object properties recursively
+     * @param lhs contains reference to first object of comparison
+     * @param rhs contains reference to second object of comparison
+     * @param stack contains prefix name for current object propery
+     */
+    getChangedProperties: function(lhs, rhs, stack) {
+      if (stack == null) {
+          stack = '';
+      }
+
+      var properties = [];
+      for (var key in rhs) {
+        if (typeof rhs[key] == 'object') {
+          var obj_properties = this.getChangedProperties(
+            lhs[key], rhs[key], key + '.'
+          );
+          properties = properties.concat(obj_properties);
+        } else if (lhs[key] != rhs[key]) {
+          properties.push(stack + key);
+        }
+      }
+
+      return properties;
     }
   }
 );

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -685,26 +685,6 @@ SDL.RadioModel = Em.Object.create({
     this.setRadioData(this.lastOptionParams);
   },
 
-  getChangedProperties: function(lhs, rhs, stack) {
-    if (stack == null) {
-        stack = '';
-    }
-
-    var properties = [];
-    for (var key in rhs) {
-      if (typeof rhs[key] == 'object') {
-        var obj_properties = this.getChangedProperties(
-          lhs[key], rhs[key], key + '.'
-        );
-        properties = properties.concat(obj_properties);
-      } else if (lhs[key] != rhs[key]) {
-        properties.push(stack + key);
-      }
-    }
-
-    return properties;
-  },
-
   bandSelect: function(element) {
       SDL.RadioModel.band = element.selection.name;
     },
@@ -1163,7 +1143,7 @@ SDL.RadioModel = Em.Object.create({
     var beforeChange = SDL.deepCopy(this.lastOptionParams);
     this.saveCurrentOptions();
     var afterChange = SDL.deepCopy(this.lastOptionParams);
-    var properties = this.getChangedProperties(beforeChange, afterChange);
+    var properties = SDL.SDLController.getChangedProperties(beforeChange, afterChange);
 
     SDL.RadioModel.toggleProperty('optionsEnabled');
     this.sendRadioChangeNotification(properties);


### PR DESCRIPTION
Added shared function `OnAcEnableChanged/OnAcMaxEnableChanged` which is used in both toggle AC, AC_MAX buttons manually and in setting AC, AC_MAX values directly using `SetInteriorVehicleData` RPC.

Also updated logic for setting climate data - there will be all actually changed properties in response in addition to requested ones.