### PR TITLE
Fix ButtonPress/SetInteriorVehicleData behaviour

### DIFF
--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -64,12 +64,6 @@ SDL.RController = SDL.SDLController.extend(
       };
 
       if (params.moduleType == 'CLIMATE') {
-        if (SDL.States.currentState.get('path') != 'climate') {
-          result_struct.resultCode = SDL.SDLModel.data.resultCode.IGNORED;
-          result_struct.resultInfo = 'Climate module must be activated';
-          return result_struct;
-        }
-
         var model = SDL.ClimateController.model;
         switch (params.buttonName) {
           case 'AC_MAX': {

--- a/ffw/RCRPC.js
+++ b/ffw/RCRPC.js
@@ -196,7 +196,16 @@ FFW.RC = FFW.RPCObserver.create(
               return;
             }
 
-            if (request.params.moduleData.radioControlData != null) {
+            if (request.params.moduleData.radioControlData) {
+              if (request.params.moduleData.radioControlData.radioEnable == null
+                  && SDL.RadioModel.radioControlStruct.radioEnable == false) {
+                this.sendError(
+                  SDL.SDLModel.data.resultCode.IGNORED,
+                  request.id, request.method,
+                  'Radio module must be activated.'
+                );
+                return;
+              }
               if (!SDL.RadioModel.checkRadioFrequencyBoundaries(
                     request.params.moduleData.radioControlData)) {
                 this.sendError(


### PR DESCRIPTION
Allow `ButtonPress` for climate module from any place.
Disallow `SetInteriorVehicleData` for disabled radio.



